### PR TITLE
correct spelling for 3 instance of 'houshold'

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -206,12 +206,12 @@ def lambda_handler(event, context):
           'visualization': 'ChoroplethMap',
         },
         '026': {
-          'name': 'Householders Living Alone',
+          'name': 'Housholders Living Alone',
           'endpoint':'http://service.civicpdx.org/neighborhood-development/sandbox/foundations/livingalone/',
           'visualization': 'ChoroplethMap',
         },
         '027': {
-          'name': 'Owner Occupied Households',
+          'name': 'Owner Occupied Housholds',
           'endpoint':'http://service.civicpdx.org/neighborhood-development/sandbox/foundations/owneroccupied/',
           'visualization': 'ChoroplethMap',
          },

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -171,7 +171,7 @@ def lambda_handler(event, context):
           'visualization': 'ChoroplethMap',
         },
         '018': {
-          'name': 'Median Houshold Income',
+          'name': 'Median Household Income',
           'endpoint':'http://service.civicpdx.org/neighborhood-development/sandbox/foundations/income/',
           'visualization': 'ChoroplethMap',
         },
@@ -206,12 +206,12 @@ def lambda_handler(event, context):
           'visualization': 'ChoroplethMap',
         },
         '026': {
-          'name': 'Housholders Living Alone',
+          'name': 'Householders Living Alone',
           'endpoint':'http://service.civicpdx.org/neighborhood-development/sandbox/foundations/livingalone/',
           'visualization': 'ChoroplethMap',
         },
         '027': {
-          'name': 'Owner Occupied Housholds',
+          'name': 'Owner Occupied Households',
           'endpoint':'http://service.civicpdx.org/neighborhood-development/sandbox/foundations/owneroccupied/',
           'visualization': 'ChoroplethMap',
          },

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -171,7 +171,7 @@ def lambda_handler(event, context):
           'visualization': 'ChoroplethMap',
         },
         '018': {
-          'name': 'Median Household Income',
+          'name': 'Median Houshold Income',
           'endpoint':'http://service.civicpdx.org/neighborhood-development/sandbox/foundations/income/',
           'visualization': 'ChoroplethMap',
         },


### PR DESCRIPTION
1. foundation 018: "median houshold income" - _http://service.civicpdx.org/neighborhood-development/sandbox/foundations/income/_ (issue #5)

2. foundation 026: "Housholders Living Alone" (_http://service.civicpdx.org/neighborhood-development/sandbox/foundations/livingalone/_)

3. foundation 027: "Owner Occupied Housholds" (_http://service.civicpdx.org/neighborhood-
development/sandbox/foundations/owneroccupied/_)